### PR TITLE
Update dependency gl_exception_notifier

### DIFF
--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -1,6 +1,5 @@
 ---
-RuboCop-version: 1.65.1 (using Parser 3.3.4.0, rubocop-ast 1.32.0, running on ruby
-  3.2.5)
+RuboCop-version: 1.65.1 (using Parser 3.3.4.0, rubocop-ast 1.32.0, running on ruby 3.2.5)
 Bundler/DuplicatedGem:
   Severity: warning
   VersionAdded: '0.46'

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -1,5 +1,6 @@
 ---
-RuboCop-version: 1.65.1 (using Parser 3.3.4.0, rubocop-ast 1.32.0, running on ruby 3.2.5)
+RuboCop-version: 1.65.1 (using Parser 3.3.4.2, rubocop-ast 1.32.0, running on ruby
+  3.2.5)
 Bundler/DuplicatedGem:
   Severity: warning
   VersionAdded: '0.46'

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,9 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  # gem 'factory_bot' # remove?
   gem 'gl_lint'
   gem 'guard-rspec'
   gem 'rails'
-  # gem 'rake' # remove?
   gem 'rspec'
   gem 'rspec-rails'
   gem 'rubocop', '1.65.1' # Lock to reduce churn in .rubocop_rules.yml

--- a/gl_command.gemspec
+++ b/gl_command.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files = %w[gl_command.gemspec README.md LICENSE] + `git ls-files | grep -E '^(lib)'`.split("\n")
 
   spec.add_dependency 'activerecord', '>= 3.2.0'
-  spec.add_dependency 'gl_exception_notifier'
+  spec.add_dependency 'gl_exception_notifier', '>= 1.0.2'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/gl_command/callable.rb
+++ b/lib/gl_command/callable.rb
@@ -2,7 +2,6 @@
 
 require 'active_support/core_ext/module'
 require 'gl_exception_notifier'
-require 'sentry-ruby' # Remove once gl_exception_notifier is 1.0.2
 require 'gl_command/validatable'
 
 module GLCommand

--- a/lib/gl_command/version.rb
+++ b/lib/gl_command/version.rb
@@ -1,3 +1,3 @@
 module GLCommand
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end

--- a/spec/lib/rubocop_rules_spec.rb
+++ b/spec/lib/rubocop_rules_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe '.rubocop_rules.yml' do # rubocop:disable RSpec/DescribeClass
-  rules_ruby_version = '3.2.4' # Update this when the rules are written with a new Ruby version
+  rules_ruby_version = '3.2.5' # Update this when the rules are written with a new Ruby version
 
   # Don't match on patch version
   rules_version_matches = rules_ruby_version.split('.')[0..1] == RUBY_VERSION.split('.')[0..1]


### PR DESCRIPTION
Update `gl_exception_notifier` version so that we can remove an unnecessary requires.

Also, fix the `rubocop_rules` spec that failed on master