### PR TITLE
Improve context.errors handling

### DIFF
--- a/lib/gl_command/context.rb
+++ b/lib/gl_command/context.rb
@@ -26,9 +26,9 @@ module GLCommand
     attr_writer :full_error_message
 
     # If someone calls errors on a context, they expect to get the errors!
-    # Make that work, but also try to make it clear that they probably shouldn't be using that for presentation
+    # Include the errors from
     def errors
-      current_errors&.add(:base, "full_error_message: #{full_error_message}") if @failure && current_errors.blank?
+      current_errors&.add(:base, "Command Error: #{full_error_message}") if add_command_error?
       current_errors
     end
 
@@ -132,6 +132,17 @@ module GLCommand
       @callable&.errors
     end
 
+    def add_command_error?
+      return false if @error.blank?
+
+      return true if current_errors.blank?
+
+      # Add command error unless the existing error is a validation error or there's already a command error
+      return false if  @error&.class == ActiveRecord::RecordInvalid
+
+      current_errors.full_messages.none? { |err| err.start_with?('Command Error: ') }
+    end
+
     def exception?(passed_error)
       passed_error.is_a?(Exception) ||
         (passed_error.respond_to?(:ancestors) && passed_error.ancestors.include?(Exception))
@@ -145,7 +156,7 @@ module GLCommand
     def merge_errors(new_errors)
       # When merging the errors, don't add duplicate errors
       new_errors.each do |new_error|
-        errors.import(new_error) unless errors&.full_messages&.include?(new_error.full_message)
+        current_errors.import(new_error) unless current_errors&.full_messages&.include?(new_error.full_message)
       end
     end
 

--- a/lib/gl_command/context.rb
+++ b/lib/gl_command/context.rb
@@ -25,8 +25,7 @@ module GLCommand
     attr_reader :klass, :error
     attr_writer :full_error_message
 
-    # If someone calls errors on a context, they expect to get the errors!
-    # Include the errors from
+    # If someone calls #errors, they expect to get the errors! Include the non-validation error, if it exists
     def errors
       current_errors&.add(:base, "Command Error: #{full_error_message}") if add_command_error?
       current_errors
@@ -138,9 +137,8 @@ module GLCommand
       return true if current_errors.blank?
 
       # Add command error unless the existing error is a validation error or there's already a command error
-      return false if  @error&.class == ActiveRecord::RecordInvalid
-
-      current_errors.full_messages.none? { |err| err.start_with?('Command Error: ') }
+      @error&.class != ActiveRecord::RecordInvalid &&
+        current_errors.full_messages.none? { |err| err.start_with?('Command Error: ') }
     end
 
     def exception?(passed_error)

--- a/lib/gl_command/version.rb
+++ b/lib/gl_command/version.rb
@@ -1,3 +1,3 @@
 module GLCommand
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.1.2'.freeze
 end

--- a/spec/lib/gl_command/chainable_spec.rb
+++ b/spec/lib/gl_command/chainable_spec.rb
@@ -209,6 +209,7 @@ RSpec.describe GLCommand::Chainable do
       it 'adds an error' do
         expect(GLExceptionNotifier).not_to receive(:call)
         expect(result).not_to be_successful
+        expect(result.errors.full_messages).to eq(['Array Must be an array with no blank items!'])
         expect(result.error.to_s).to eq target_error_message
         expect(result.full_error_message).to eq target_error_message
         expect(result.error.class).to eq(ActiveRecord::RecordInvalid)

--- a/spec/lib/gl_command/validatable_spec.rb
+++ b/spec/lib/gl_command/validatable_spec.rb
@@ -218,7 +218,6 @@ RSpec.describe GLCommand::Validatable do
     it 'returns the errors' do
       expect(result).to be_a_failure
       expect(result.errors.count).to eq 1
-      # make it explicit that this is a full_error_message
       expect(result.full_error_message).to eq 'Raised error message!'
       expect(result.errors.full_messages).to eq(['Command Error: Raised error message!'])
     end
@@ -229,7 +228,6 @@ RSpec.describe GLCommand::Validatable do
       it 'returns the errors' do
         expect(result).to be_a_failure
         expect(result.errors.count).to eq 2
-        # make it explicit that this is a full_error_message
         expect(result.full_error_message).to eq 'Raised error message!'
         expect(result.errors.full_messages.sort).to eq(['Command Error: Raised error message!', 'validation error'])
       end
@@ -238,10 +236,10 @@ RSpec.describe GLCommand::Validatable do
     context 'with skip_raising' do
       let(:validation_error) { 'validation error' }
       let(:skip_raising) { true }
+
       it 'returns with just the validation error' do
         expect(result).to be_a_failure
         expect(result.errors.count).to eq 1
-        # make it explicit that this is a full_error_message
         expect(result.full_error_message).to eq 'Validation failed: validation error'
         expect(result.errors.full_messages.sort).to eq(['validation error'])
       end


### PR DESCRIPTION
Follow up to #14 - add command error consistently to the context.