### PR TITLE
Update gemspec license to remove warning about nonstandard license

### DIFF
--- a/gl_command.gemspec
+++ b/gl_command.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ['Give Lively']
   spec.summary = 'Give Lively Commands'
   spec.homepage = 'https://github.com/givelively/gl_command'
-  spec.license = 'Apache'
+  spec.license = 'Apache-2.0'
   spec.platform = Gem::Platform::RUBY
 
   spec.required_ruby_version = '>= 3.1'

--- a/lib/gl_command/version.rb
+++ b/lib/gl_command/version.rb
@@ -1,3 +1,3 @@
 module GLCommand
-  VERSION = '1.1.2'.freeze
+  VERSION = '1.1.3'.freeze
 end


### PR DESCRIPTION
Warning text reads:

> WARNING:  license value 'Apache' is invalid.  Use a license identifier from http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.