### PR TITLE
Add ENV to always bang

### DIFF
--- a/lib/gl_command/callable.rb
+++ b/lib/gl_command/callable.rb
@@ -6,6 +6,7 @@ require 'gl_command/validatable'
 
 module GLCommand
   class Callable
+    ALWAYS_RAISE_ERRORS = ENV['GL_COMMAND_ALWAYS_RAISE'] == 'true'
     DEFAULT_OPTS = { raise_errors: false, skip_unknown_parameters: true, in_chain: false }.freeze
     RESERVED_WORDS = (DEFAULT_OPTS.keys + GLCommand::ChainableContext.reserved_words).sort.freeze
 
@@ -27,6 +28,7 @@ module GLCommand
         # (rather than in context initialize) to make errors more legible
         opts = DEFAULT_OPTS.merge(raise_errors: args.delete(:raise_errors),
                                   in_chain: args.delete(:in_chain)).compact
+        opts[:raise_errors] = true if ALWAYS_RAISE_ERRORS
         # args are passed in in perform_call(args) so that invalid args raise in a legible place
         new(build_context(**args.merge(opts))).perform_call(args)
       end

--- a/lib/gl_command/callable.rb
+++ b/lib/gl_command/callable.rb
@@ -26,9 +26,8 @@ module GLCommand
 
         # DEFAULT_OPTS contains skip_unknown_parameters: true - so it raises on call
         # (rather than in context initialize) to make errors more legible
-        opts = DEFAULT_OPTS.merge(raise_errors: args.delete(:raise_errors),
+        opts = DEFAULT_OPTS.merge(raise_errors: args.delete(:raise_errors) || ALWAYS_RAISE_ERRORS,
                                   in_chain: args.delete(:in_chain)).compact
-        opts[:raise_errors] = true if ALWAYS_RAISE_ERRORS
         # args are passed in in perform_call(args) so that invalid args raise in a legible place
         new(build_context(**args.merge(opts))).perform_call(args)
       end

--- a/lib/gl_command/version.rb
+++ b/lib/gl_command/version.rb
@@ -1,3 +1,3 @@
 module GLCommand
-  VERSION = '1.1.3'.freeze
+  VERSION = '1.1.4'.freeze
 end

--- a/spec/lib/gl_command/callable_spec.rb
+++ b/spec/lib/gl_command/callable_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe GLCommand::Callable do
             expect_any_instance_of(ArrayAdd).to receive(:instrument_command).with(:before_call).once
             expect_any_instance_of(ArrayAdd)
               .to receive(:instrument_command).with(:before_rollback).once
+            expect(GLExceptionNotifier).not_to receive(:call)
             result = ArrayAdd.call(array:, item: 6)
             failure_expectations(result)
             expect(result).to be_raise_error

--- a/spec/lib/gl_command/callable_spec.rb
+++ b/spec/lib/gl_command/callable_spec.rb
@@ -52,6 +52,19 @@ RSpec.describe GLCommand::Callable do
           end.to raise_error(/Test Error/)
         end
       end
+      context 'with ALWAYS_RAISE_ERRORS' do
+        before { stub_const('GLCommand::Callable::ALWAYS_RAISE_ERRORS', true) }
+        it 'runs rollback and raises' do
+          expect do
+            expect_any_instance_of(ArrayAdd).to receive(:instrument_command).with(:before_call).once
+            expect_any_instance_of(ArrayAdd)
+              .to receive(:instrument_command).with(:before_rollback).once
+            result = ArrayAdd.call(array:, item: 6)
+            failure_expectations(result)
+            expect(result).to be_raise_error
+          end.to raise_error(/Test Error/)
+        end
+      end
     end
   end
 

--- a/spec/lib/gl_command/callable_spec.rb
+++ b/spec/lib/gl_command/callable_spec.rb
@@ -52,8 +52,10 @@ RSpec.describe GLCommand::Callable do
           end.to raise_error(/Test Error/)
         end
       end
+
       context 'with ALWAYS_RAISE_ERRORS' do
         before { stub_const('GLCommand::Callable::ALWAYS_RAISE_ERRORS', true) }
+
         it 'runs rollback and raises' do
           expect do
             expect_any_instance_of(ArrayAdd).to receive(:instrument_command).with(:before_call).once


### PR DESCRIPTION
Sometimes, when diagnosing problems locally, you just want the original error to raise.

Rather than finding the call site and changing the `call` into a `call!`, just set the environmental variable `GL_COMMAND_ALWAYS_RAISE` to `"true"`

I thought about adding a note to the documentation about this - but really, it's something that you should only do if you know about it - so I'm not sure it should be in the readme.

[DEV-10287](https://give-lively.atlassian.net/browse/DEV-10287)