### PR TITLE
In chains, pass the ChainableContext to in_chain (instead of true)

### DIFF
--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -67,6 +67,7 @@ GLCops/CallbackMethodNames: {}
 GLCops/InteractorInheritsFromInteractorBase:
   Include:
   - app/interactors/**/*
+GLCops/NoStubbingPerformAsync: {}
 GLCops/PreventErbFiles: {}
 GLCops/RailsCache: {}
 GLCops/SidekiqInheritsFromSidekiqJob:
@@ -146,6 +147,22 @@ Layout/CaseIndentation:
   EnforcedStyle: case
   IndentOneStep: false
   IndentationWidth:
+Layout/ClassStructure:
+  VersionAdded: '0.52'
+  VersionChanged: '1.53'
+  Categories:
+    module_inclusion:
+    - include
+    - prepend
+    - extend
+  ExpectedOrder:
+  - module_inclusion
+  - constants
+  - public_class_methods
+  - initializer
+  - public_methods
+  - protected_methods
+  - private_methods
 Layout/ClosingHeredocIndentation:
   VersionAdded: '0.57'
 Layout/ClosingParenthesisIndentation:

--- a/lib/gl_command/callable.rb
+++ b/lib/gl_command/callable.rb
@@ -6,6 +6,7 @@ require 'gl_command/validatable'
 
 module GLCommand
   class Callable
+    include GLCommand::Validatable
     ALWAYS_RAISE_ERRORS = ENV['GL_COMMAND_ALWAYS_RAISE'] == 'true'
     DEFAULT_OPTS = { raise_errors: false, skip_unknown_parameters: true, in_chain: false }.freeze
     RESERVED_WORDS = (DEFAULT_OPTS.keys + GLCommand::ChainableContext.reserved_words).sort.freeze
@@ -101,8 +102,6 @@ module GLCommand
         attributes.index_with { nil }.merge(strong_attributes)
       end
     end
-
-    include GLCommand::Validatable
 
     attr_reader :context
 

--- a/lib/gl_command/chainable.rb
+++ b/lib/gl_command/chainable.rb
@@ -41,7 +41,7 @@ module GLCommand
 
       commands.map do |command|
         cargs = context.chain_arguments_and_returns.slice(*command.arguments)
-                       .merge(context.opts_hash).merge(in_chain: self)
+                       .merge(context.opts_hash).merge(in_chain: context)
 
         # using _result to make sure it doesn't cause naming conflicts with other uses of result
         _result = command.call(**cargs)

--- a/lib/gl_command/chainable.rb
+++ b/lib/gl_command/chainable.rb
@@ -41,7 +41,7 @@ module GLCommand
 
       commands.map do |command|
         cargs = context.chain_arguments_and_returns.slice(*command.arguments)
-                       .merge(context.opts_hash).merge(in_chain: true)
+                       .merge(context.opts_hash).merge(in_chain: self)
 
         # using _result to make sure it doesn't cause naming conflicts with other uses of result
         _result = command.call(**cargs)

--- a/lib/gl_command/context.rb
+++ b/lib/gl_command/context.rb
@@ -22,7 +22,7 @@ module GLCommand
       { raise_errors: raise_errors? }
     end
 
-    attr_reader :klass, :error
+    attr_reader :klass, :error, :in_chain
     attr_writer :full_error_message
 
     # If someone calls #errors, they expect to get the errors! Include the non-validation error, if it exists
@@ -33,10 +33,6 @@ module GLCommand
 
     def chain?
       false
-    end
-
-    def in_chain
-      @in_chain
     end
 
     def returns

--- a/lib/gl_command/context.rb
+++ b/lib/gl_command/context.rb
@@ -35,7 +35,7 @@ module GLCommand
       false
     end
 
-    def in_chain?
+    def in_chain
       @in_chain
     end
 

--- a/lib/gl_command/version.rb
+++ b/lib/gl_command/version.rb
@@ -1,3 +1,3 @@
 module GLCommand
-  VERSION = '1.1.4'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/spec/lib/gl_command/chainable_spec.rb
+++ b/spec/lib/gl_command/chainable_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe GLCommand::Chainable do
         expect(result.arguments).to eq({ string: '810693451' })
         # Verify chain information
         expect(result).to be_chain
-        expect(result).not_to be_in_chain
+        expect(result.in_chain).to be_falsey
       end
     end
 
@@ -207,7 +207,8 @@ RSpec.describe GLCommand::Chainable do
         expect(result.new_array).to eq array + [11]
         expect(result.revised_item).to eq 11
         expect(result.called).to eq([ArrayAdd, ArrayPop])
-        expect(result.is_in_chain).to be_truthy
+        pp result
+        expect(result.in_chain).to be_an_instance_of(GLCommand::Chainable)
       end
       # rubocop:enable RSpec/MultipleExpectations
     end

--- a/spec/lib/gl_command/chainable_spec.rb
+++ b/spec/lib/gl_command/chainable_spec.rb
@@ -207,8 +207,8 @@ RSpec.describe GLCommand::Chainable do
         expect(result.new_array).to eq array + [11]
         expect(result.revised_item).to eq 11
         expect(result.called).to eq([ArrayAdd, ArrayPop])
-        pp result
-        expect(result.in_chain).to be_an_instance_of(GLCommand::Chainable)
+        expect(result.is_in_chain).to be_an_instance_of(GLCommand::ChainableContext)
+        expect(result.is_in_chain.to_h).to eq result.to_h.except(:in_chain)
       end
       # rubocop:enable RSpec/MultipleExpectations
     end

--- a/spec/lib/gl_command/context_spec.rb
+++ b/spec/lib/gl_command/context_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe GLCommand::Context do
   # rubocop:disable RSpec/MultipleExpectations
   let(:context_instance_methods) do
     %i[arguments assign_callable assign_parameters chain? error error= errors failure?
-       full_error_message full_error_message= in_chain? klass no_notifiable_error_to_raise
+       full_error_message full_error_message= in_chain klass no_notifiable_error_to_raise
        no_notify? opts_hash raise_errors? returns success? successful? to_h]
   end
 
@@ -25,7 +25,7 @@ RSpec.describe GLCommand::Context do
       expect(context.returns).to eq({})
       expect(context.to_h).to eq({})
       expect(context).not_to be_chain
-      expect(context).not_to be_in_chain
+      expect(context.in_chain).to be_falsey
     end
 
     it 'only has the base methods' do

--- a/spec/test_command_classes.rb
+++ b/spec/test_command_classes.rb
@@ -38,7 +38,7 @@ class ArrayPop < GLCommand::Callable
   def call
     context.popped_item = array.pop
     context.popped_array = array.dup
-    context.is_in_chain = context.in_chain?
+    context.is_in_chain = context.in_chain
   end
 end
 


### PR DESCRIPTION
So the `ChainableContext` can be operated on by the chain.

![image](https://github.com/user-attachments/assets/32640887-00e2-4418-a534-1ad0c07e58a9)

This also renames the `in_chain?` method on `GlCommand::Context` to `in_chain` since it is no longer a boolean.

Bump minor version because this is a change not a bug fix, but it's an internal method so it shouldn't break things (considering the userbase of this gem)
