### PR TITLE
Add tests for insturment_command and no_notify behavior in chains

### DIFF
--- a/spec/lib/gl_command/callable_spec.rb
+++ b/spec/lib/gl_command/callable_spec.rb
@@ -630,4 +630,43 @@ RSpec.describe GLCommand::Callable do
       end
     end
   end
+
+  describe 'instrument_command triggers' do
+    let(:instruments_triggered) { [] }
+    let(:fail_error) { false }
+    let(:result) { TestInstrumentTriggers.call(instruments_triggered:, fail_error:) }
+
+    it 'returns before_call and after_call' do
+      expect(result).to be_successful
+      expect(result.instruments_triggered).to eq(%i[before_call after_call])
+    end
+
+    context 'with fail_error' do
+      let(:fail_error) { true }
+
+      it 'returns before_call and before_rollback' do
+        expect(result).to be_failure
+        expect(result.instruments_triggered).to eq(%i[before_call before_rollback])
+      end
+    end
+
+    context 'with call!' do
+      let(:result) { TestInstrumentTriggers.call!(instruments_triggered:, fail_error:) }
+
+      it 'returns before_call and after_call' do
+        expect(result).to be_successful
+        expect(result.instruments_triggered).to eq(%i[before_call after_call])
+      end
+
+      context 'with fail_error' do
+        let(:fail_error) { true }
+
+        it 'returns before_call and before_rollback' do
+          expect { result }.to raise_error(GLCommand::StopAndFail)
+
+          expect(instruments_triggered).to eq(%i[before_call before_rollback])
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/gl_command/chainable_spec.rb
+++ b/spec/lib/gl_command/chainable_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe GLCommand::Chainable do
         chain ArrayPop, ArrayStopAndFail
       end
     end
+    let(:error_message) { 'This command always fails!' }
     let(:array) { [42] }
     let(:no_notify_val) { nil }
 
@@ -130,8 +131,8 @@ RSpec.describe GLCommand::Chainable do
       expect(GLExceptionNotifier).to receive(:call)
       result = test_class.call(array:, no_notify_val:)
       expect(result).to be_a_failure
-      expect(result.error.to_s).to eq 'This command always fails!'
-      expect(result.full_error_message).to eq 'This command always fails!'
+      expect(result.error.to_s).to eq error_message
+      expect(result.full_error_message).to eq error_message
       expect(result.error.class).to eq(GLCommand::StopAndFail)
     end
 
@@ -142,8 +143,8 @@ RSpec.describe GLCommand::Chainable do
         expect(GLExceptionNotifier).to receive(:call)
         result = test_class.call(array:, no_notify_val:)
         expect(result).to be_a_failure
-        expect(result.error.to_s).to eq 'This command always fails!'
-        expect(result.full_error_message).to eq 'This command always fails!'
+        expect(result.error.to_s).to eq error_message
+        expect(result.full_error_message).to eq error_message
         expect(result.error.class).to eq(GLCommand::StopAndFail)
       end
     end
@@ -155,8 +156,8 @@ RSpec.describe GLCommand::Chainable do
         expect(GLExceptionNotifier).not_to receive(:call)
         result = test_class.call(array:, no_notify_val:)
         expect(result).to be_a_failure
-        expect(result.error.to_s).to eq 'This command always fails!'
-        expect(result.full_error_message).to eq 'This command always fails!'
+        expect(result.error.to_s).to eq error_message
+        expect(result.full_error_message).to eq error_message
         expect(result.error.class).to eq(GLCommand::StopAndFail)
       end
     end
@@ -167,7 +168,7 @@ RSpec.describe GLCommand::Chainable do
 
         expect do
           test_class.call!(array:, no_notify_val:)
-        end.to raise_error(/This command always fails/)
+        end.to raise_error(error_message)
       end
 
       context 'with no_notify: false' do
@@ -178,7 +179,7 @@ RSpec.describe GLCommand::Chainable do
 
           expect do
             test_class.call!(array:, no_notify_val:)
-          end.to raise_error(/This command always fails/)
+          end.to raise_error(GLCommand::StopAndFail)
         end
       end
 
@@ -190,7 +191,16 @@ RSpec.describe GLCommand::Chainable do
 
           expect do
             test_class.call!(array:, no_notify_val:)
-          end.to raise_error(/This command always fails/)
+          end.to raise_error(error_message)
+        end
+
+        it 'raises a GLCommand::StopAndFail error with cause of GLCommand::CommandNoNotifyError' do
+          test_class.call!(array:, no_notify_val:)
+        rescue GLCommand::StopAndFail => e
+          expect(e.to_s).to eq error_message
+          expect(e.cause).to be_present
+          expect(e.cause.class).to eq GLCommand::CommandNoNotifyError
+          expect(e.cause.to_s).to eq error_message
         end
       end
     end

--- a/spec/lib/gl_command/chainable_spec.rb
+++ b/spec/lib/gl_command/chainable_spec.rb
@@ -126,24 +126,24 @@ RSpec.describe GLCommand::Chainable do
     let(:array) { [42] }
     let(:no_notify_val) { nil }
 
-    it "fails and notifies" do
+    it 'fails and notifies' do
       expect(GLExceptionNotifier).to receive(:call)
       result = test_class.call(array:, no_notify_val:)
       expect(result).to be_a_failure
-      expect(result.error.to_s).to eq "This command always fails!"
-      expect(result.full_error_message).to eq "This command always fails!"
+      expect(result.error.to_s).to eq 'This command always fails!'
+      expect(result.full_error_message).to eq 'This command always fails!'
       expect(result.error.class).to eq(GLCommand::StopAndFail)
     end
 
     context 'with no_notify: false' do
       let(:no_notify_val) { false }
 
-      it "fails and notifies" do
+      it 'fails and notifies' do
         expect(GLExceptionNotifier).to receive(:call)
         result = test_class.call(array:, no_notify_val:)
         expect(result).to be_a_failure
-        expect(result.error.to_s).to eq "This command always fails!"
-        expect(result.full_error_message).to eq "This command always fails!"
+        expect(result.error.to_s).to eq 'This command always fails!'
+        expect(result.full_error_message).to eq 'This command always fails!'
         expect(result.error.class).to eq(GLCommand::StopAndFail)
       end
     end
@@ -155,8 +155,8 @@ RSpec.describe GLCommand::Chainable do
         expect(GLExceptionNotifier).not_to receive(:call)
         result = test_class.call(array:, no_notify_val:)
         expect(result).to be_a_failure
-        expect(result.error.to_s).to eq "This command always fails!"
-        expect(result.full_error_message).to eq "This command always fails!"
+        expect(result.error.to_s).to eq 'This command always fails!'
+        expect(result.full_error_message).to eq 'This command always fails!'
         expect(result.error.class).to eq(GLCommand::StopAndFail)
       end
     end
@@ -165,24 +165,32 @@ RSpec.describe GLCommand::Chainable do
       it "raises and doesn't notify" do
         expect(GLExceptionNotifier).not_to receive(:call)
 
-        expect { test_class.call!(array:, no_notify_val:) }.to raise_error(/This command always fails/)
+        expect do
+          test_class.call!(array:, no_notify_val:)
+        end.to raise_error(/This command always fails/)
       end
 
-      context "with no_notify: false" do
+      context 'with no_notify: false' do
         let(:no_notify_val) { false }
+
         it "raises and doesn't notify" do
           expect(GLExceptionNotifier).not_to receive(:call)
 
-          expect { test_class.call!(array:, no_notify_val:) }.to raise_error(/This command always fails/)
+          expect do
+            test_class.call!(array:, no_notify_val:)
+          end.to raise_error(/This command always fails/)
         end
       end
 
-      context "with no_notify: true" do
+      context 'with no_notify: true' do
         let(:no_notify_val) { true }
+
         it "raises and doesn't notify" do
           expect(GLExceptionNotifier).not_to receive(:call)
 
-          expect { test_class.call!(array:, no_notify_val:) }.to raise_error(/This command always fails/)
+          expect do
+            test_class.call!(array:, no_notify_val:)
+          end.to raise_error(/This command always fails/)
         end
       end
     end

--- a/spec/lib/gl_command/chainable_spec.rb
+++ b/spec/lib/gl_command/chainable_spec.rb
@@ -110,6 +110,84 @@ RSpec.describe GLCommand::Chainable do
     end
   end
 
+  describe 'stop_and_fail! with no_notify: in chain' do
+    let(:test_class) do
+      Class.new(GLCommand::Chainable) do
+        # Need to set the class name for validatable, or it raises: Class name cannot be blank.
+        def self.name
+          'TestChainableClass'
+        end
+
+        requires :array
+        allows :no_notify_val
+        chain ArrayPop, ArrayStopAndFail
+      end
+    end
+    let(:array) { [42] }
+    let(:no_notify_val) { nil }
+
+    it "fails and notifies" do
+      expect(GLExceptionNotifier).to receive(:call)
+      result = test_class.call(array:, no_notify_val:)
+      expect(result).to be_a_failure
+      expect(result.error.to_s).to eq "This command always fails!"
+      expect(result.full_error_message).to eq "This command always fails!"
+      expect(result.error.class).to eq(GLCommand::StopAndFail)
+    end
+
+    context 'with no_notify: false' do
+      let(:no_notify_val) { false }
+
+      it "fails and notifies" do
+        expect(GLExceptionNotifier).to receive(:call)
+        result = test_class.call(array:, no_notify_val:)
+        expect(result).to be_a_failure
+        expect(result.error.to_s).to eq "This command always fails!"
+        expect(result.full_error_message).to eq "This command always fails!"
+        expect(result.error.class).to eq(GLCommand::StopAndFail)
+      end
+    end
+
+    context 'with no_notify: true' do
+      let(:no_notify_val) { true }
+
+      it "fails and doesn't notify" do
+        expect(GLExceptionNotifier).not_to receive(:call)
+        result = test_class.call(array:, no_notify_val:)
+        expect(result).to be_a_failure
+        expect(result.error.to_s).to eq "This command always fails!"
+        expect(result.full_error_message).to eq "This command always fails!"
+        expect(result.error.class).to eq(GLCommand::StopAndFail)
+      end
+    end
+
+    context 'with call!' do
+      it "raises and doesn't notify" do
+        expect(GLExceptionNotifier).not_to receive(:call)
+
+        expect { test_class.call!(array:, no_notify_val:) }.to raise_error(/This command always fails/)
+      end
+
+      context "with no_notify: false" do
+        let(:no_notify_val) { false }
+        it "raises and doesn't notify" do
+          expect(GLExceptionNotifier).not_to receive(:call)
+
+          expect { test_class.call!(array:, no_notify_val:) }.to raise_error(/This command always fails/)
+        end
+      end
+
+      context "with no_notify: true" do
+        let(:no_notify_val) { true }
+        it "raises and doesn't notify" do
+          expect(GLExceptionNotifier).not_to receive(:call)
+
+          expect { test_class.call!(array:, no_notify_val:) }.to raise_error(/This command always fails/)
+        end
+      end
+    end
+  end
+
   describe 'without call defined' do
     let(:test_class) do
       Class.new(GLCommand::Chainable) do

--- a/spec/test_command_classes.rb
+++ b/spec/test_command_classes.rb
@@ -50,12 +50,12 @@ class ArrayStopAndFail < GLCommand::Chainable
   returns :new_array
 
   def call
-    stop_and_fail_args = if no_notify_val == nil
-      {}
-    else
-      {no_notify: no_notify_val}
-    end
-    stop_and_fail!("This command always fails!", **stop_and_fail_args)
+    stop_and_fail_args = if no_notify_val.nil?
+                           {}
+                         else
+                           { no_notify: no_notify_val }
+                         end
+    stop_and_fail!('This command always fails!', **stop_and_fail_args)
   end
 end
 

--- a/spec/test_command_classes.rb
+++ b/spec/test_command_classes.rb
@@ -42,6 +42,23 @@ class ArrayPop < GLCommand::Callable
   end
 end
 
+class ArrayStopAndFail < GLCommand::Chainable
+  requires :array
+
+  allows :no_notify_val
+
+  returns :new_array
+
+  def call
+    stop_and_fail_args = if no_notify_val == nil
+      {}
+    else
+      {no_notify: no_notify_val}
+    end
+    stop_and_fail!("This command always fails!", **stop_and_fail_args)
+  end
+end
+
 class ArrayChain < GLCommand::Chainable
   requires :array, :item
   chain ArrayAdd, ArrayPop

--- a/spec/test_command_classes.rb
+++ b/spec/test_command_classes.rb
@@ -222,3 +222,23 @@ class TestScope < GLCommand::Callable
     context.context_as_string = context.inspect
   end
 end
+
+class TestInstrumentTriggers < GLCommand::Callable
+  requires instruments_triggered: Array
+
+  allows :fail_error
+
+  returns instruments_triggered: Array
+
+  def call
+    return if fail_error.blank?
+
+    stop_and_fail!(fail_error, no_notify: true)
+  end
+
+  private
+
+  def instrument_command(trigger)
+    instruments_triggered << trigger
+  end
+end


### PR DESCRIPTION
- Add tests for `no_notify` behavior
- Also add tests for `instrument_command` triggers

We were investigating an error in Sentry that showed `CommandNoNotifyError`:

<img width="953" alt="Screenshot 2025-04-24 at 11 51 59 AM" src="https://github.com/user-attachments/assets/c44e977f-3acf-424e-aa7b-9e4936c92e0a" />

... it turns out that sentry is just displaying the error cause and not making it clear that it's a nested error (see [this article about nested errors and error cause](https://www.honeybadger.io/blog/nested-errors-in-ruby-with-exception-cause/))

This PR only adds tests, so no version bump is required