### PR TITLE
feat: Implement default values for contract attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ spec/support/database.yml
 # .rubocop-https?--*
 
 db
+.aider*
+.env

--- a/lib/gl/command/contract.rb
+++ b/lib/gl/command/contract.rb
@@ -103,7 +103,7 @@ module GL
       klass.instance_variable_get(:@defaults).each do |attr, default|
         next if context.to_h.key?(attr)
 
-        value = default.is_a?(Proc) ? instance_eval(&default) : default
+        value = default.is_a?(Proc) ? instance_exec(&default) : default
         context[attr] = value
       end
     end

--- a/lib/gl/command/contract.rb
+++ b/lib/gl/command/contract.rb
@@ -7,18 +7,30 @@ module GL
         include ActiveModel::Validations
         extend ClassMethods
 
+        before :apply_defaults!
         before :validate_contract!
         after :validate_return_contract!
       end
     end
 
     module ClassMethods
+      def self.extended(base)
+        base.instance_variable_set(:@defaults, {})
+      end
+
+      def inherited(subclass)
+        super
+        defaults = instance_variable_get(:@defaults)
+        subclass.instance_variable_set(:@defaults, defaults.dup)
+      end
+
       def allows(*attributes, **strong_attributes)
         delegate(*attributes, to: :context)
         return if strong_attributes.blank?
 
-        delegate(*strong_attributes.keys, to: :context)
-        enforce_attribute_types(**strong_attributes)
+        typed_attributes = parse_strong_attributes(**strong_attributes)
+        delegate(*typed_attributes.keys, to: :context)
+        enforce_attribute_types(**typed_attributes)
       end
 
       def requires(*attributes, **strong_attributes)
@@ -36,9 +48,9 @@ module GL
       def requires_strong_attributes(**attributes)
         return if attributes.blank?
 
-        attribute_keys = attributes.keys
-        requires_attributes(*attribute_keys)
-        enforce_attribute_types(**attributes)
+        typed_attributes = parse_strong_attributes(**attributes)
+        requires_attributes(*typed_attributes.keys)
+        enforce_attribute_types(**typed_attributes)
       end
 
       def returns(*attributes, **strong_attributes)
@@ -69,8 +81,30 @@ module GL
 
       private
 
+      def parse_strong_attributes(**attributes)
+        simple_attributes = attributes.select { |_, v| !v.is_a?(Hash) }
+        complex_attributes = attributes.select { |_, v| v.is_a?(Hash) }
+
+        complex_attributes.each do |attr, opts|
+          @defaults[attr] = opts[:default] if opts.key?(:default)
+        end
+
+        simple_attributes.merge(
+          complex_attributes.transform_values { |v| v[:type] }.compact
+        )
+      end
+
       def type_applies?(value, type)
         value.is_a?(type) || value.acts_like?(type.name.downcase.to_sym)
+      end
+    end
+
+    def apply_defaults!
+      klass.instance_variable_get(:@defaults).each do |attr, default|
+        next if context.to_h.key?(attr)
+
+        value = default.is_a?(Proc) ? instance_eval(&default) : default
+        context[attr] = value
       end
     end
 

--- a/spec/gl/command_spec.rb
+++ b/spec/gl/command_spec.rb
@@ -119,6 +119,42 @@ RSpec.describe GL::Command do
             expect(test_class.call(foo: 'a')).to be_successful
           end
         end
+
+        context 'with default option' do
+          context 'with a value' do
+            let(:test_class) do
+              Class.new(BaseCommand) do
+                requires foo: { type: String, default: 'default_foo' }
+                requires :bar
+              end
+            end
+
+            it 'uses the default value if none is given' do
+              expect(test_class.call(bar: 'baz').foo).to eq 'default_foo'
+            end
+
+            it 'uses the given value' do
+              expect(test_class.call(foo: 'given_foo', bar: 'baz').foo).to eq 'given_foo'
+            end
+
+            it 'uses a given nil value' do
+              expect(test_class.call(foo: nil, bar: 'baz').foo).to be_nil
+            end
+          end
+
+          context 'with a proc' do
+            let(:test_class) do
+              Class.new(BaseCommand) do
+                requires foo: { type: String, default: -> { 'proc_foo' } }
+                requires :bar
+              end
+            end
+
+            it 'uses the default value if none is given' do
+              expect(test_class.call(bar: 'baz').foo).to eq 'proc_foo'
+            end
+          end
+        end
       end
 
       context 'when using :allows' do
@@ -187,6 +223,35 @@ RSpec.describe GL::Command do
 
           it 'delegates variable to the context' do
             expect(test_class.call).to be_successful
+          end
+        end
+      end
+
+      context 'when using defaults' do
+        context 'with inheritance' do
+          let(:parent_class) do
+            Class.new(BaseCommand) do
+              allows number: { type: Integer, default: 1 }
+            end
+          end
+
+          let(:child_class) do
+            Class.new(parent_class) do
+              allows name: { type: String, default: 'name' }
+            end
+          end
+
+          it 'inherits defaults from parent' do
+            context = child_class.call
+            expect(context.number).to eq 1
+            expect(context.name).to eq 'name'
+          end
+
+          it 'does not leak defaults to parent' do
+            child_class.call
+            context = parent_class.call
+            expect(context.number).to eq 1
+            expect(context.name).to be_nil
           end
         end
       end


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                            
This pull request introduces the ability to specify default values for attributes in a command's contract using requires and allows. This enhancement makes commands more robust and their interfaces more declarative by reducing boilerplate code for handling optional or missing        
parameters.                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                            
Both static values and lazily-evaluated procs are supported for defaults, and inheritance is handled correctly.                                                                                                                                                                             
                                                                                                                                                                                                                                                                                            
**The Approach**                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                            
1. Extended Contract Syntax: The requires and allows methods were updated to accept a hash of options for an attribute, including :type and :default. This maintains backward compatibility with the simpler attribute: Type syntax.                                                        
2. Centralized Parsing: A private helper method, parse_strong_attributes, was introduced in GL::Command::Contract to process these attributes. It extracts the default configurations and stores them in a new @defaults class instance variable.                                           
3. Applying Defaults via Hooks: A new before hook, apply_defaults!, was added. This hook runs before contract validation (validate_contract!) and populates the context with default values for any keys that were not provided in the initial call.                                        
4. Proc Evaluation: To support dynamic defaults (e.g., -> { Time.now }), the apply_defaults! method uses instance_exec to evaluate procs within the context of the command instance. This ensures the proc is executed only when needed (lazy evaluation).                                  
5. Inheritance: The inherited hook was implemented to ensure that a child command inherits a deep copy of its parent's @defaults hash, preventing defaults defined in a child from modifying its parent.                                                                                    
                                                                                                                                                                                                                                                                                            
**Advantages**                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                            
 • Reduces Boilerplate: Eliminates the need for manual default assignment inside the call method (e.g., context.page ||= 1), making the business logic cleaner.                                                                                                                             
 • Declarative API: A command's inputs and their defaults are now clearly defined in one place, improving readability and making the command's interface self-documenting.                                                                                                                  
 • Lazy Evaluation: Using a proc for a default value ensures that expensive operations (like creating a new object or running a query) are only performed if the value is actually needed.                                                                                                  
 • Increased Robustness: Commands become more resilient and predictable when called with missing optional parameters.                                                                                                                                                                       
                                                                                                                                                                                                                                                                                            
**Usage Examples**                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                            
You can now provide a :default option for any attribute defined with requires or allows.                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                            
Example with a static default value:

```ruby
class SearchCommand < GLCommand::Callable
  allows page: { type: Integer, default: 1 }

  def call
    # context.page is guaranteed to be an Integer here.
    search_for_results(page: page)
  end
end

# Usage:
SearchCommand.call # context.page is 1
SearchCommand.call(page: 3) # context.page is 3
```

```ruby
class CreatePostCommand < GLCommand::Callable
  requires :title, :author
  # The `published_at` parameter will default to the current time.
  # The proc is only executed if `published_at` is not provided.
  allows published_at: { type: Time, default: -> { Time.now } }

  def call
    Post.create(title: title, author: author, published_at: published_at)
  end
end

# Usage:
CreatePostCommand.call(title: 'New Post', author: 'Me')
# => `published_at` is set to Time.now
```