### PR TITLE
Fix/additive keywords

### DIFF
--- a/lib/gl_command/callable.rb
+++ b/lib/gl_command/callable.rb
@@ -47,21 +47,35 @@ module GLCommand
       end
 
       def requires(*attributes, **strong_attributes)
-        @requires ||= strong_args_hash(*attributes, **strong_attributes).freeze
+        @requires ||= {}
+        if attributes.empty? && strong_attributes.empty?
+          return @requires
+        end
+        @arguments = nil # Reset memoized arguments
+        @requires = @requires.merge(strong_args_hash(*attributes, **strong_attributes))
       end
 
       def allows(*attributes, **strong_attributes)
-        @allows ||= strong_args_hash(*attributes, **strong_attributes).freeze
+        @allows ||= {}
+        if attributes.empty? && strong_attributes.empty?
+          return @allows
+        end
+        @arguments = nil # Reset memoized arguments
+        @allows = @allows.merge(strong_args_hash(*attributes, **strong_attributes))
       end
 
       def returns(*attributes, **strong_attributes)
+        @returns ||= []
+        if attributes.empty? && strong_attributes.empty?
+          return @returns
+        end
         # NOTE: Because returns aren't validated, we don't store the types (only store keys)
-        @returns ||= strong_args_hash(*attributes, **strong_attributes).keys.freeze
+        @returns += strong_args_hash(*attributes, **strong_attributes).keys
       end
 
       # arguments are what's passed to the .call command (the allows and requires)
       def arguments
-        return @arguments if defined?(@arguments)
+        return @arguments if defined?(@arguments) && @arguments
 
         duplicated_keys = requires.keys & allows.keys
         raise "Duplicated: #{duplicated_keys} - in both requires and allows" if duplicated_keys.any?

--- a/spec/lib/gl_command/callable_spec.rb
+++ b/spec/lib/gl_command/callable_spec.rb
@@ -385,7 +385,8 @@ RSpec.describe GLCommand::Callable do
 
     context 'with error' do
       let(:error) { ActiveRecord::RecordNotFound.new('Some error class') }
-      let(:result) { CreateTestNpo.build_context(error:) }
+      let(:result) { CreateTestNpo.build_context(error:)
+ }
 
       it 'is failure' do
         expect(result).to be_a_failure
@@ -634,7 +635,8 @@ RSpec.describe GLCommand::Callable do
   describe 'instrument_command triggers' do
     let(:instruments_triggered) { [] }
     let(:fail_error) { false }
-    let(:result) { TestInstrumentTriggers.call(instruments_triggered:, fail_error:) }
+    let(:result) { TestInstrumentTriggers.call(instruments_triggered:, fail_error:)
+ }
 
     it 'returns before_call and after_call' do
       expect(result).to be_successful
@@ -651,7 +653,8 @@ RSpec.describe GLCommand::Callable do
     end
 
     context 'with call!' do
-      let(:result) { TestInstrumentTriggers.call!(instruments_triggered:, fail_error:) }
+      let(:result) { TestInstrumentTriggers.call!(instruments_triggered:, fail_error:)
+ }
 
       it 'returns before_call and after_call' do
         expect(result).to be_successful
@@ -667,6 +670,42 @@ RSpec.describe GLCommand::Callable do
           expect(instruments_triggered).to eq(%i[before_call before_rollback after_rollback])
         end
       end
+    end
+  end
+
+  describe 'additive keywords' do
+    let(:test_class) do
+      Class.new(GLCommand::Callable) do
+        requires :arg1
+        requires arg2: String
+
+        allows :opt1
+        allows opt2: Integer
+
+        returns :ret1
+        returns :ret2
+
+        def call; end
+      end
+    end
+
+    it 'accumulates arguments and returns from multiple calls' do
+      expect(test_class.arguments).to contain_exactly(:arg1, :arg2, :opt1, :opt2)
+      expect(test_class.instance_variable_get(:@requires)).to eq({ arg1: nil, arg2: String })
+      expect(test_class.instance_variable_get(:@allows)).to eq({ opt1: nil, opt2: Integer })
+      expect(test_class.instance_variable_get(:@returns)).to contain_exactly(:ret1, :ret2)
+    end
+
+    it 'is successful with all arguments' do
+      result = test_class.call(arg1: 'foo', arg2: 'bar', opt1: 'baz', opt2: 123)
+      expect(result).to be_successful
+    end
+
+    it 'is unsuccessful without required arguments' do
+      result = test_class.call(opt1: 'baz', opt2: 123)
+      expect(result).not_to be_successful
+      expect(result.error.class).to eq ArgumentError
+      expect(result.error.to_s).to match(/missing keywords: :arg1, :arg2/)
     end
   end
 end

--- a/spec/lib/gl_command/callable_spec.rb
+++ b/spec/lib/gl_command/callable_spec.rb
@@ -385,8 +385,7 @@ RSpec.describe GLCommand::Callable do
 
     context 'with error' do
       let(:error) { ActiveRecord::RecordNotFound.new('Some error class') }
-      let(:result) { CreateTestNpo.build_context(error:)
- }
+      let(:result) { CreateTestNpo.build_context(error:) }
 
       it 'is failure' do
         expect(result).to be_a_failure
@@ -635,8 +634,7 @@ RSpec.describe GLCommand::Callable do
   describe 'instrument_command triggers' do
     let(:instruments_triggered) { [] }
     let(:fail_error) { false }
-    let(:result) { TestInstrumentTriggers.call(instruments_triggered:, fail_error:)
- }
+    let(:result) { TestInstrumentTriggers.call(instruments_triggered:, fail_error:) }
 
     it 'returns before_call and after_call' do
       expect(result).to be_successful
@@ -653,8 +651,7 @@ RSpec.describe GLCommand::Callable do
     end
 
     context 'with call!' do
-      let(:result) { TestInstrumentTriggers.call!(instruments_triggered:, fail_error:)
- }
+      let(:result) { TestInstrumentTriggers.call!(instruments_triggered:, fail_error:) }
 
       it 'returns before_call and after_call' do
         expect(result).to be_successful


### PR DESCRIPTION
This pull request addresses an issue where the `requires`, `allows`, and `returns` keywords in GLCommand::Callable would overwrite previously defined values instead of being additive. This change modifies their behavior to merge new values with existing ones, enabling them to be called multiple times within the same command.

Changes include:
 - Additive Keywords: The core logic in callable.rb has been updated to ensure that multiple calls to requires, allows, and returns accumulate their arguments.
 - Regression Testing: A new test suite has been added to spec/lib/gl_command/callable_spec.rb to verify the additive behavior and prevent future regressions.
 - Method Adjustments: The arguments and arguments_and_returns methods have been updated to correctly handle the new implementation.