### PR TITLE
Always return errors

### DIFF
--- a/lib/gl_command/context.rb
+++ b/lib/gl_command/context.rb
@@ -27,7 +27,7 @@ module GLCommand
 
     # If someone calls #errors, they expect to get the errors! Include the non-validation error, if it exists
     def errors
-      current_errors&.add(:base, "Command Error: #{full_error_message}") if add_command_error?
+      current_errors&.add(:base, full_error_message) if add_command_error?
       current_errors
     end
 
@@ -136,7 +136,7 @@ module GLCommand
 
       # Add command error unless the existing error is a validation error or there's already a command error
       @error&.class != ActiveRecord::RecordInvalid &&
-        current_errors.full_messages.none? { |err| err.start_with?('Command Error: ') }
+        current_errors.full_messages.none? { |err| err == @error.message }
     end
 
     def exception?(passed_error)

--- a/lib/gl_command/context.rb
+++ b/lib/gl_command/context.rb
@@ -126,7 +126,10 @@ module GLCommand
     private
 
     def current_errors
-      @callable&.errors
+      return @callable.errors if defined?(@callable)
+
+      # @standalone_errors only is instantiated when you use build_context
+      (@standalone_errors ||= ActiveModel::Errors.new(self))
     end
 
     def add_command_error?

--- a/spec/lib/gl_command/callable_spec.rb
+++ b/spec/lib/gl_command/callable_spec.rb
@@ -391,6 +391,8 @@ RSpec.describe GLCommand::Callable do
         expect(result).to be_a_failure
         expect(result.full_error_message).to eq 'Some error class'
         expect(result.error.class).to eq ActiveRecord::RecordNotFound
+        expect(result.errors.map(&:class)).to eq([ActiveModel::Error])
+        expect(result.errors.full_messages).to eq(['Some error class'])
       end
     end
   end

--- a/spec/lib/gl_command/validatable_spec.rb
+++ b/spec/lib/gl_command/validatable_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe GLCommand::Validatable do
       expect(result).to be_a_failure
       expect(result.errors.count).to eq 1
       expect(result.full_error_message).to eq 'Raised error message!'
-      expect(result.errors.full_messages).to eq(['Command Error: Raised error message!'])
+      expect(result.errors.full_messages).to eq(['Raised error message!'])
     end
 
     context 'with validation_error' do
@@ -228,7 +228,7 @@ RSpec.describe GLCommand::Validatable do
         expect(result).to be_a_failure
         expect(result.errors.count).to eq 2
         expect(result.full_error_message).to eq 'Raised error message!'
-        expect(result.errors.full_messages.sort).to eq(['Command Error: Raised error message!',
+        expect(result.errors.full_messages.sort).to eq(['Raised error message!',
                                                         'validation error'])
       end
     end


### PR DESCRIPTION
Previously, `#errors` didn't work for contexts that had been built with `build_context`

```ruby
result = build_context(error: "Something")`
result.errors # => nil
```

Also, remove the `Command Error: ` prefix from non-active record errors.