### PR TITLE
Add bin/release script for publishing the gem

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -31,15 +31,37 @@ if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
   exit 1
 fi
 
-bundle exec rspec || { echo "Error: specs failed, aborting release"; exit 1; }
-
+# main is protected, so the version bump goes through a PR
+RELEASE_BRANCH="release-v$VERSION"
+git checkout -b "$RELEASE_BRANCH"
 printf "module GLCommand\n  VERSION = '$VERSION'.freeze\nend\n" > ./lib/gl_command/version.rb
 bundle
 git add Gemfile.lock lib/gl_command/version.rb
 git commit -m "Bump version for $VERSION"
-git push
+git push -u origin "$RELEASE_BRANCH"
+
+gh pr create --base main --title "Bump version for $VERSION" --body "Automated version bump for the $VERSION release."
+gh pr merge "$RELEASE_BRANCH" --squash --auto
+
+echo "Waiting for the release PR to merge (auto-merges once CI passes)..."
+while true; do
+  STATE=$(gh pr view "$RELEASE_BRANCH" --json state --jq .state)
+  case "$STATE" in
+    MERGED) break ;;
+    CLOSED)
+      echo "Error: release PR was closed without merging"
+      exit 1
+      ;;
+    *) sleep 10 ;;
+  esac
+done
+
+git checkout main
+git pull origin main
+git branch -d "$RELEASE_BRANCH"
+
 git tag v$VERSION
-git push --tags
+git push origin v$VERSION
 gem build gl_command.gemspec
 gem push "gl_command-$VERSION.gem" --host https://rubygems.org
 rm "gl_command-$VERSION.gem"

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+VERSION=$1
+
+if [ -z "$VERSION" ]; then
+  echo "bin/release needs a version!"
+  echo ""
+  echo "Example: bin/release 1.5.0"
+  exit 1
+fi
+
+if ! [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+){0,2}$ ]]; then
+  echo "Error: invalid version '$VERSION' (expected something like 1.5.0)"
+  exit 1
+fi
+
+# Normalize to a three-part version (e.g. 1.5 -> 1.5.0)
+while [[ "$VERSION" != *.*.* ]]; do
+  VERSION="$VERSION.0"
+done
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" != "main" ]; then
+  echo "Error: must be on main branch to release (currently on $BRANCH)"
+  exit 1
+fi
+
+git fetch origin main
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+  echo "Error: local main is not up to date with origin/main"
+  exit 1
+fi
+
+bundle exec rspec || { echo "Error: specs failed, aborting release"; exit 1; }
+
+printf "module GLCommand\n  VERSION = '$VERSION'.freeze\nend\n" > ./lib/gl_command/version.rb
+bundle
+git add Gemfile.lock lib/gl_command/version.rb
+git commit -m "Bump version for $VERSION"
+git push
+git tag v$VERSION
+git push --tags
+gem build gl_command.gemspec
+gem push "gl_command-$VERSION.gem" --host https://rubygems.org
+rm "gl_command-$VERSION.gem"
+gh release create "v$VERSION" --title "v$VERSION" --generate-notes

--- a/bin/release
+++ b/bin/release
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-VERSION=$1
+# Abort on any unchecked failure so we never publish a release for a version
+# that didn't actually make it to RubyGems (e.g. a failed `gem push`).
+set -euo pipefail
+
+VERSION="${1:-}"
 
 if [ -z "$VERSION" ]; then
   echo "bin/release needs a version!"

--- a/bin/release
+++ b/bin/release
@@ -64,9 +64,13 @@ git checkout main
 git pull origin main
 git branch -d "$RELEASE_BRANCH"
 
-git tag v$VERSION
-git push origin v$VERSION
+# Publish the gem first; the tag and GitHub release are only created once the
+# gem has actually made it to RubyGems. This keeps a failed `gem push` from
+# leaving behind a tag that points at an unpublished release (and blocks re-runs).
 gem build gl_command.gemspec
 gem push "gl_command-$VERSION.gem" --host https://rubygems.org
 rm "gl_command-$VERSION.gem"
+
+git tag v$VERSION
+git push origin v$VERSION
 gh release create "v$VERSION" --title "v$VERSION" --generate-notes


### PR DESCRIPTION
Modeled after [hotwired/turbo-rails](https://github.com/hotwired/turbo-rails/blob/main/bin/release) and [bikeindex/binxtils](https://github.com/bikeindex/binxtils/blob/main/bin/release) release scripts: 
- validates the version arg
- ensures main is clean and up to date
- runs the spec suite
- bumps lib/gl_command/version.rb
- checks out a new branch, commits/tags/pushes with auto-merge (so the PR auto merges when specs pass)
- builds and pushes the gem to rubygems.org, and creates a GitHub release.